### PR TITLE
test: add tests for JD, hallucination, DOCX/MD support

### DIFF
--- a/tests/test_cover_letter_generation.py
+++ b/tests/test_cover_letter_generation.py
@@ -289,3 +289,134 @@ class TestConfirmDraft:
             generation_params={"attempt": 2},
         )
         assert result == 99
+
+    @patch("cover_letter.generation_service._get_conn")
+    def test_hallucination_retries_param_saved(self, mock_conn):
+        """hallucination_retries 파라미터가 DB에 전달된다."""
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (100,)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_c = MagicMock()
+        mock_c.__enter__ = MagicMock(return_value=mock_c)
+        mock_c.__exit__ = MagicMock(return_value=False)
+        mock_c.cursor.return_value = mock_cursor
+        mock_conn.return_value = mock_c
+
+        result = generation_service.confirm_draft(
+            question_id=1,
+            mapping_table_id=None,
+            text="답변",
+            self_diagnosis_issues=[],
+            generation_params={},
+            hallucination_retries=2,
+        )
+        assert result == 100
+        execute_args = mock_cursor.execute.call_args[0][1]
+        # hallucination_retries = 2 가 params에 포함됐는지 확인
+        assert 2 in execute_args
+
+
+# ============================================================
+# check_hallucination 테스트
+# ============================================================
+class TestCheckHallucination:
+    @patch("cover_letter.generation_service.llm_client.call")
+    def test_returns_false_when_not_hallucinated(self, mock_call):
+        """LLM이 hallucinated=false 반환 시 False."""
+        mock_call.return_value = '{"hallucinated": false, "reason": "정상"}'
+        result = generation_service.check_hallucination(
+            answer_text="A사 인턴 경험에서 개발했습니다.",
+            mapping_entries=_ENTRIES,
+            profile=_PROFILE,
+        )
+        assert result is False
+
+    @patch("cover_letter.generation_service.llm_client.call")
+    def test_returns_true_when_hallucinated(self, mock_call):
+        """LLM이 hallucinated=true 반환 시 True."""
+        mock_call.return_value = '{"hallucinated": true, "reason": "없는 프로젝트"}'
+        result = generation_service.check_hallucination(
+            answer_text="없는프로젝트 팀장으로 활동했습니다.",
+            mapping_entries=_ENTRIES,
+            profile=_PROFILE,
+        )
+        assert result is True
+
+    @patch("cover_letter.generation_service.llm_client.call")
+    def test_returns_false_on_json_parse_error(self, mock_call):
+        """LLM 응답이 파싱 불가능하면 False(보수적 판단)."""
+        mock_call.return_value = "잘못된 응답"
+        result = generation_service.check_hallucination(
+            answer_text="답변 텍스트",
+            mapping_entries=_ENTRIES,
+            profile=_PROFILE,
+        )
+        assert result is False
+
+
+# ============================================================
+# regenerate_without_hallucination 테스트
+# ============================================================
+class TestRegenerateWithoutHallucination:
+    _ANSWER_PARAMS = dict(
+        question_id=1,
+        question_text="지원 동기를 서술하시오.",
+        char_limit=1000,
+        target_char_min=800,
+        target_char_max=950,
+        measured_competencies=[],
+        expected_level="",
+        company_analysis=_COMPANY,
+        job_analysis=_JOB,
+        profile=_PROFILE,
+        mapping_entries=_ENTRIES,
+        user_instruction="",
+    )
+
+    @patch("cover_letter.generation_service.check_hallucination", return_value=False)
+    @patch("cover_letter.generation_service.generate_answer")
+    def test_returns_without_retrying_if_no_hallucination(self, mock_gen, mock_hall):
+        """첫 시도에서 환각이 없으면 재생성하지 않는다."""
+        mock_gen.return_value = {
+            "text": "정상 답변",
+            "char_count": 850,
+            "in_range": True,
+            "attempt": 1,
+        }
+
+        result = generation_service.regenerate_without_hallucination(
+            answer_params=self._ANSWER_PARAMS,
+            mapping_entries=_ENTRIES,
+            profile=_PROFILE,
+        )
+
+        assert result["hallucination_retries"] == 0
+        assert result["hallucination_detected"] is False
+        assert mock_gen.call_count == 1
+
+    @patch(
+        "cover_letter.generation_service.check_hallucination",
+        side_effect=[True, True, True, True],
+    )
+    @patch("cover_letter.generation_service.generate_answer")
+    def test_retries_up_to_max_retries_then_gives_up(self, mock_gen, mock_hall):
+        """MAX_RETRIES 초과 후에도 환각이 있으면 hallucination_detected=True 반환."""
+        mock_gen.return_value = {
+            "text": "환각 포함 답변",
+            "char_count": 900,
+            "in_range": True,
+            "attempt": 1,
+        }
+        original_max = generation_service.MAX_RETRIES
+        generation_service.MAX_RETRIES = 3
+
+        result = generation_service.regenerate_without_hallucination(
+            answer_params=self._ANSWER_PARAMS,
+            mapping_entries=_ENTRIES,
+            profile=_PROFILE,
+        )
+
+        generation_service.MAX_RETRIES = original_max
+        assert result["hallucination_retries"] == 3
+        assert result["hallucination_detected"] is True

--- a/tests/test_cover_letter_jd.py
+++ b/tests/test_cover_letter_jd.py
@@ -1,0 +1,176 @@
+"""jd_crawler + jd_service 단위 테스트."""
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cover_letter import jd_service
+from cover_letter.collectors import jd_crawler
+
+
+# ============================================================
+# jd_crawler.crawl_jd 테스트
+# ============================================================
+class TestCrawlJD:
+    def _make_firecrawl_app(self, items: list[dict]) -> MagicMock:
+        app = MagicMock()
+        app.search.return_value = items
+        return app
+
+    @patch("cover_letter.collectors.jd_crawler.os.getenv", return_value="fake-key")
+    @patch("cover_letter.collectors.jd_crawler.FirecrawlApp", create=True)
+    def test_firecrawl_success_returns_text(self, mock_fc_cls, mock_getenv):
+        mock_fc_cls.return_value = self._make_firecrawl_app(
+            [
+                {
+                    "url": "https://example.com/job",
+                    "markdown": "## 직무 기술서\n- Python 필수",
+                }
+            ]
+        )
+
+        with patch.dict(
+            "sys.modules", {"firecrawl": MagicMock(FirecrawlApp=mock_fc_cls)}
+        ):
+            result = jd_crawler.crawl_jd("카카오", "백엔드 개발자")
+
+        assert result["success"] is True
+        assert result["source_type"] == "firecrawl"
+        assert result["text"] is not None
+
+    @patch("cover_letter.collectors.jd_crawler.os.getenv", return_value="fake-key")
+    @patch("cover_letter.collectors.jd_crawler.FirecrawlApp", create=True)
+    def test_pdf_url_triggers_pdfminer_fallback(self, mock_fc_cls, mock_getenv):
+        """PDF URL 감지 시 pdfminer fallback이 호출된다."""
+        mock_fc_cls.return_value = self._make_firecrawl_app(
+            [{"url": "https://example.com/jd.pdf", "markdown": ""}]
+        )
+
+        with patch(
+            "cover_letter.collectors.jd_crawler._extract_pdf_from_url"
+        ) as mock_pdf:
+            mock_pdf.return_value = "PDF에서 추출된 직무기술서 내용"
+            with patch.dict(
+                "sys.modules", {"firecrawl": MagicMock(FirecrawlApp=mock_fc_cls)}
+            ):
+                result = jd_crawler.crawl_jd("삼성", "SW 개발자")
+
+        assert result["success"] is True
+        assert result["source_type"] == "pdf"
+
+    @patch("cover_letter.collectors.jd_crawler.os.getenv", return_value="")
+    def test_missing_api_key_returns_manual(self, mock_getenv):
+        """FIRECRAWL_API_KEY 없으면 manual 반환."""
+        result = jd_crawler.crawl_jd("당근마켓", "iOS 개발자")
+        assert result["success"] is False
+        assert result["source_type"] == "manual"
+        assert result["text"] is None
+
+    @patch("cover_letter.collectors.jd_crawler.os.getenv", return_value="fake-key")
+    @patch("cover_letter.collectors.jd_crawler.FirecrawlApp", create=True)
+    def test_firecrawl_exception_returns_manual(self, mock_fc_cls, mock_getenv):
+        """Firecrawl 예외 시 manual 반환."""
+        mock_app = MagicMock()
+        mock_app.search.side_effect = Exception("네트워크 오류")
+        mock_fc_cls.return_value = mock_app
+
+        with patch.dict(
+            "sys.modules", {"firecrawl": MagicMock(FirecrawlApp=mock_fc_cls)}
+        ):
+            result = jd_crawler.crawl_jd("네이버", "데이터 분석가")
+
+        assert result["success"] is False
+        assert result["source_type"] == "manual"
+
+
+# ============================================================
+# jd_service.extract_required_competencies 테스트
+# ============================================================
+class TestExtractRequiredCompetencies:
+    @patch("cover_letter.jd_service.llm_client.call")
+    def test_returns_list_from_json_array(self, mock_call):
+        mock_call.return_value = '["Python", "문제해결력", "팀워크"]'
+        result = jd_service.extract_required_competencies("Python 3년 이상 경험자 우대")
+        assert "Python" in result
+        assert isinstance(result, list)
+
+    @patch("cover_letter.jd_service.llm_client.call")
+    def test_strips_markdown_codeblock(self, mock_call):
+        mock_call.return_value = '```json\n["협업", "커뮤니케이션"]\n```'
+        result = jd_service.extract_required_competencies("JD 텍스트")
+        assert "협업" in result
+
+    @patch("cover_letter.jd_service.llm_client.call")
+    def test_invalid_json_returns_empty_list(self, mock_call):
+        mock_call.return_value = "이건 JSON이 아님"
+        result = jd_service.extract_required_competencies("JD 텍스트")
+        assert result == []
+
+
+# ============================================================
+# jd_service.save_jd / load_jd DB 왕복 테스트
+# ============================================================
+class TestSaveLoadJD:
+    _JD_DATA = {
+        "success": True,
+        "text": "Python, FastAPI 개발 경험 필수",
+        "source_url": "https://example.com/job",
+        "source_type": "firecrawl",
+        "required_competencies": ["Python", "FastAPI"],
+    }
+
+    @patch("cover_letter.jd_service._get_conn")
+    def test_save_jd_executes_upsert(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = (42,)
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result_id = jd_service.save_jd(1, self._JD_DATA)
+
+        mock_cur.execute.assert_called_once()
+        sql = mock_cur.execute.call_args[0][0]
+        assert "INSERT INTO jd" in sql
+        assert "ON CONFLICT" in sql
+        assert result_id == 42
+
+    @patch("cover_letter.jd_service._get_conn")
+    def test_load_jd_returns_none_when_no_row(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = None
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = jd_service.load_jd(999)
+        assert result is None
+
+    @patch("cover_letter.jd_service._get_conn")
+    def test_load_jd_returns_dict_when_row_exists(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = (
+            7,  # id
+            "Python, FastAPI 개발 경험 필수",  # raw_text
+            "https://example.com/job",  # source_url
+            "firecrawl",  # source_type
+            ["Python", "FastAPI"],  # required_competencies
+            {},  # user_overrides
+            "2026-04-10 00:00:00+00:00",  # collected_at
+        )
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = jd_service.load_jd(1)
+        assert result is not None
+        assert result["id"] == 7
+        assert result["source_type"] == "firecrawl"
+        assert "Python" in result["required_competencies"]

--- a/tests/test_cover_letter_profile.py
+++ b/tests/test_cover_letter_profile.py
@@ -43,6 +43,39 @@ class TestParseInput:
         with pytest.raises(ValueError):
             profile_service.parse_input("", b"")
 
+    def test_md_file_returns_decoded_text(self):
+        """filename 확장자가 .md일 때 UTF-8 디코드로 처리한다."""
+        md_bytes = b"# \xed\x83\x80\xec\x9d\xb4\xed\x8b\x80\n\xeb\x82\xb4\xec\x9a\xa9"  # UTF-8 '타이틀\n내용'
+        result = profile_service.parse_input(None, md_bytes, filename="resume.md")
+        assert "타이틀" in result
+        assert "내용" in result
+
+    def test_txt_with_filename_returns_decoded_text(self):
+        """filename 확장자가 .txt일 때도 UTF-8 디코드로 처리한다."""
+        txt_bytes = "파이썬 개발자".encode("utf-8")
+        result = profile_service.parse_input(None, txt_bytes, filename="data.txt")
+        assert "파이썬" in result
+
+    @patch("docx.Document")
+    def test_docx_file_extracts_paragraph_text(self, mock_doc_cls):
+        """filename 확장자가 .docx일 때 python-docx 단락 텍스트를 추출한다."""
+        mock_para1 = MagicMock()
+        mock_para1.text = "백엔드 인턴 경험"
+        mock_para2 = MagicMock()
+        mock_para2.text = "FastAPI 개발"
+        mock_para_empty = MagicMock()
+        mock_para_empty.text = ""
+
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [mock_para1, mock_para_empty, mock_para2]
+        mock_doc_cls.return_value = mock_doc
+
+        result = profile_service.parse_input(
+            None, b"fake-docx-bytes", filename="portfolio.docx"
+        )
+        assert "백엔드 인턴 경험" in result
+        assert "FastAPI 개발" in result
+
 
 # ============================================================
 # extract_profile 테스트


### PR DESCRIPTION
## Summary
JD 서비스, 환각 감지, DOCX/MD 파일 업로드에 대한 테스트 추가

## Type of Change
- [x] Test

## Changes Made
- `tests/test_cover_letter_jd.py` (신규): JDService 유닛 테스트
  - URL 크롤링, 텍스트 입력, DB 저장, 오류 처리
- `tests/test_cover_letter_generation.py`: 환각 감지/재생성 테스트 추가
  - `check_hallucination()`, `regenerate_without_hallucination()`, `confirm_draft()`
- `tests/test_cover_letter_profile.py`: DOCX·MD 파싱 테스트 추가
  - `parse_input()` 확장 분기 커버리지

## Dependencies
이 PR은 다음 PR들과 함께 병합 필요:
- #52 feat(cover-letter): add JD service, models, API key validation
- #53 feat(profile): support DOCX and MD file uploads
- #54 feat(generation): add hallucination detection and prevention

## Testing
- [x] Pre-commit hooks pass (mypy 오류는 cross-branch 의존성 artifact)

## Related Issues
Part of #001-cover-letter-automation feature